### PR TITLE
Fix dark mode card backgrounds

### DIFF
--- a/src/components/AboutUs.tsx
+++ b/src/components/AboutUs.tsx
@@ -108,7 +108,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
   }, []);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="about" 
         onNavigate={onNavigate} 
@@ -131,7 +131,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
       </div>
 
       {/* Mission Section */}
-      <section ref={missionRef} className="py-16 bg-white opacity-0 transform translate-y-8">
+      <section ref={missionRef} className="py-16 bg-background opacity-0 transform translate-y-8">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div className="flex justify-center mb-6">
             <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center">
@@ -148,7 +148,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
       </section>
 
       {/* Story Section */}
-      <section ref={storyRef} className="py-16 bg-gray-50 opacity-0 transform translate-y-8">
+      <section ref={storyRef} className="py-16 bg-muted opacity-0 transform translate-y-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div>
@@ -186,7 +186,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
       </section>
 
       {/* Team Section */}
-      <section ref={teamRef} className="py-16 bg-white opacity-0 transform translate-y-8">
+      <section ref={teamRef} className="py-16 bg-background opacity-0 transform translate-y-8">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Meet Our Team</h2>
@@ -217,7 +217,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
       </section>
 
       {/* Values Section */}
-      <section ref={valuesRef} className="py-16 bg-gray-50 opacity-0 transform translate-y-8">
+      <section ref={valuesRef} className="py-16 bg-muted opacity-0 transform translate-y-8">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Our Values</h2>
@@ -262,11 +262,11 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
             Become part of a community of explorers, adventurers, and culture enthusiasts. 
             Share your stories, discover new destinations, and connect with fellow travelers.
           </p>
-          <Button 
-            size="lg" 
+          <Button
+            size="lg"
             variant="secondary"
             onClick={() => onNavigate(user ? 'account' : 'auth')}
-            className="bg-white text-primary hover:bg-gray-100 text-lg px-8 py-3"
+            className="bg-background text-primary hover:bg-muted text-lg px-8 py-3"
           >
             {user ? 'Visit Your Account' : 'Join Our Community'}
           </Button>

--- a/src/components/AdminAddGuide.tsx
+++ b/src/components/AdminAddGuide.tsx
@@ -119,7 +119,7 @@ export function AdminAddGuide({ onNavigate, user, isAdmin }: AdminAddGuideProps)
   const isFormValid = formData.title && formData.content && formData.region && formData.category;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="admin-add-guide" 
         onNavigate={onNavigate} 
@@ -168,8 +168,8 @@ export function AdminAddGuide({ onNavigate, user, isAdmin }: AdminAddGuideProps)
         </div>
 
         {/* Form Card */}
-        <Card className="bg-white shadow-sm border-gray-200">
-          <CardHeader className="border-b border-gray-200">
+        <Card className="bg-card shadow-sm border-border">
+          <CardHeader className="border-b border-border">
             <CardTitle className="text-xl font-bold text-gray-900">Guide Details</CardTitle>
           </CardHeader>
           <CardContent className="p-8">
@@ -288,7 +288,7 @@ export function AdminAddGuide({ onNavigate, user, isAdmin }: AdminAddGuideProps)
                       <img 
                         src={imagePreview} 
                         alt="Preview" 
-                        className="w-full h-48 object-cover rounded-lg border border-gray-200"
+                        className="w-full h-48 object-cover rounded-lg border border-border"
                         onError={() => setImagePreview(null)}
                       />
                     </div>
@@ -296,7 +296,7 @@ export function AdminAddGuide({ onNavigate, user, isAdmin }: AdminAddGuideProps)
                 )}
                 
                 {!imagePreview && (
-                  <div className="w-full max-w-md mx-auto md:mx-0 h-48 bg-gray-100 rounded-lg border-2 border-dashed border-gray-300 flex items-center justify-center">
+                  <div className="w-full max-w-md mx-auto md:mx-0 h-48 bg-muted rounded-lg border-2 border-dashed border-border flex items-center justify-center">
                     <div className="text-center">
                       <ImageIcon className="w-12 h-12 text-gray-400 mx-auto mb-2" />
                       <p className="text-sm text-gray-500">Image preview will appear here</p>
@@ -306,7 +306,7 @@ export function AdminAddGuide({ onNavigate, user, isAdmin }: AdminAddGuideProps)
               </div>
 
               {/* Action Buttons */}
-              <div className="flex flex-col sm:flex-row justify-end gap-4 pt-6 border-t border-gray-200">
+              <div className="flex flex-col sm:flex-row justify-end gap-4 pt-6 border-t border-border">
                 <Button 
                   type="button" 
                   variant="outline"

--- a/src/components/AdminCommentModeration.tsx
+++ b/src/components/AdminCommentModeration.tsx
@@ -160,7 +160,7 @@ export function AdminCommentModeration({ onNavigate, user, isAdmin }: AdminComme
   const flaggedCount = allComments.filter(c => c.status === 'Flagged').length;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="admin-comments" 
         onNavigate={onNavigate} 
@@ -183,7 +183,7 @@ export function AdminCommentModeration({ onNavigate, user, isAdmin }: AdminComme
         </div>
 
         {/* Main Card */}
-        <Card className="bg-white shadow-sm border-gray-200">
+        <Card className="bg-card shadow-sm border-border">
           <CardHeader className="border-b border-gray-200">
             <CardTitle className="text-xl font-bold text-gray-900">Comments & Reviews</CardTitle>
           </CardHeader>
@@ -234,9 +234,9 @@ export function AdminCommentModeration({ onNavigate, user, isAdmin }: AdminComme
 
             {/* Comments Table */}
             {paginatedComments.length > 0 ? (
-              <div className="border border-gray-200 rounded-lg overflow-hidden">
+              <div className="border border-border rounded-lg overflow-hidden">
                 <Table>
-                  <TableHeader className="bg-gray-50">
+                  <TableHeader className="bg-muted">
                     <TableRow>
                       <TableHead className="w-12">
                         <Checkbox

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -76,7 +76,7 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <div className="mb-8">
@@ -87,7 +87,7 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
           {stats.map((stat, index) => (
-            <Card key={index} className="bg-white shadow-sm border-gray-200">
+            <Card key={index} className="bg-card shadow-sm border-border">
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div>
@@ -104,7 +104,7 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
         </div>
 
         {/* Content Management */}
-        <Card className="bg-white shadow-sm border-gray-200">
+        <Card className="bg-card shadow-sm border-border">
           <CardHeader className="border-b border-gray-200">
             <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
               <CardTitle className="text-xl font-bold text-gray-900">Travel Content</CardTitle>
@@ -159,9 +159,9 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
             </div>
 
             {/* Content Table */}
-            <div className="border border-gray-200 rounded-lg overflow-hidden">
+            <div className="border border-border rounded-lg overflow-hidden">
               <Table>
-                <TableHeader className="bg-gray-50">
+                <TableHeader className="bg-muted">
                   <TableRow>
                     <TableHead className="font-medium text-gray-900">Title</TableHead>
                     <TableHead className="font-medium text-gray-900">Type</TableHead>

--- a/src/components/AdminUsers.tsx
+++ b/src/components/AdminUsers.tsx
@@ -171,7 +171,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
   const adminUsers = users.filter(u => u.role === 'Admin').length;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="admin-users" 
         onNavigate={onNavigate} 
@@ -249,7 +249,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
 
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <Card className="bg-white shadow-sm border-gray-200">
+          <Card className="bg-card shadow-sm border-border">
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
@@ -262,7 +262,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
               </div>
             </CardContent>
           </Card>
-          <Card className="bg-white shadow-sm border-gray-200">
+          <Card className="bg-card shadow-sm border-border">
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
@@ -275,7 +275,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
               </div>
             </CardContent>
           </Card>
-          <Card className="bg-white shadow-sm border-gray-200">
+          <Card className="bg-card shadow-sm border-border">
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
@@ -291,8 +291,8 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
         </div>
 
         {/* Users Table */}
-        <Card className="bg-white shadow-sm border-gray-200">
-          <CardHeader className="border-b border-gray-200">
+        <Card className="bg-card shadow-sm border-border">
+          <CardHeader className="border-b border-border">
             <CardTitle className="text-xl font-bold text-gray-900">Users</CardTitle>
           </CardHeader>
           <CardContent className="p-6">
@@ -311,9 +311,9 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
 
             {/* Users Table */}
             {filteredUsers.length > 0 ? (
-              <div className="border border-gray-200 rounded-lg overflow-hidden">
+              <div className="border border-border rounded-lg overflow-hidden">
                 <Table>
-                  <TableHeader className="bg-gray-50">
+                  <TableHeader className="bg-muted">
                     <TableRow>
                       <TableHead className="font-medium text-gray-900">User</TableHead>
                       <TableHead className="font-medium text-gray-900">Email</TableHead>
@@ -325,7 +325,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
                   </TableHeader>
                   <TableBody>
                     {filteredUsers.map((user) => (
-                      <TableRow key={user.id} className="border-gray-200">
+                      <TableRow key={user.id} className="border-border">
                         <TableCell>
                           <div className="flex items-center gap-3">
                             <Avatar className="h-10 w-10">

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -170,7 +170,7 @@ export function Auth({ onAuthSuccess, onNavigate, user, isAdmin, isAdminAuth = f
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       {onNavigate && (
         <NewNavigation 
           currentPage={isAdminAuth ? "admin-auth" : "auth"} 
@@ -190,7 +190,7 @@ export function Auth({ onAuthSuccess, onNavigate, user, isAdmin, isAdminAuth = f
         />
 
         {/* Auth Card */}
-        <Card className="relative z-10 w-full max-w-md bg-white/95 backdrop-blur-sm shadow-2xl border-0">
+        <Card className="relative z-10 w-full max-w-md bg-card/95 backdrop-blur-sm shadow-2xl border-0">
         <CardHeader className="text-center pb-6 pt-8 px-8">
           <div className="w-16 h-16 bg-orange-500 rounded-xl flex items-center justify-center mx-auto mb-6 shadow-lg">
             <span className="text-white font-bold text-xl">TQ</span>
@@ -375,7 +375,7 @@ export function Auth({ onAuthSuccess, onNavigate, user, isAdmin, isAdminAuth = f
                   <span className="w-full border-t border-gray-200" />
                 </div>
                 <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-white px-3 text-gray-500 font-medium">Or continue with</span>
+                  <span className="bg-background px-3 text-gray-500 font-medium">Or continue with</span>
                 </div>
               </div>
 

--- a/src/components/BlogDetails.tsx
+++ b/src/components/BlogDetails.tsx
@@ -227,7 +227,7 @@ export function BlogDetails({ blogId, onNavigate, user, isAdmin }: BlogDetailsPr
 
   if (!blog) {
     return (
-      <div className="min-h-screen bg-white">
+      <div className="min-h-screen bg-background">
         <NewNavigation currentPage="blogs" onNavigate={onNavigate} user={user} isAdmin={isAdmin} />
         <div className="flex items-center justify-center min-h-[50vh]">
           <div className="text-center">
@@ -240,7 +240,7 @@ export function BlogDetails({ blogId, onNavigate, user, isAdmin }: BlogDetailsPr
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       <NewNavigation currentPage="blogs" onNavigate={onNavigate} user={user} isAdmin={isAdmin} />
 
       {/* Hero Section */}
@@ -298,7 +298,7 @@ export function BlogDetails({ blogId, onNavigate, user, isAdmin }: BlogDetailsPr
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.4, duration: 0.6 }}
-        className="bg-gray-50 py-4"
+        className="bg-muted py-4"
       >
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-wrap gap-2">

--- a/src/components/BlogsPage.tsx
+++ b/src/components/BlogsPage.tsx
@@ -237,7 +237,7 @@ export function BlogsPage({ onNavigate, onBlogSelect, user, isAdmin }: BlogsPage
         </div>
 
         {/* Sticky Filter Bar */}
-        <div className="sticky top-16 z-20 bg-white/95 backdrop-blur-sm border-b border-gray-200 py-4 mb-8">
+        <div className="sticky top-16 z-20 bg-card/95 backdrop-blur-sm border-b border-border py-4 mb-8">
           <div className="flex flex-col sm:flex-row gap-4">
             {/* Search */}
             <div className="relative flex-1">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -150,7 +150,7 @@ export function Navigation({ currentPage, onNavigate, user, isAdmin }: Navigatio
   };
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-white border-b border-gray-200 h-16 shadow-sm">
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-card border-b border-border h-16 shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}

--- a/src/components/NewDestinationDetail.tsx
+++ b/src/components/NewDestinationDetail.tsx
@@ -271,7 +271,7 @@ export function NewDestinationDetail({ destinationId, onBack, onNavigate, user, 
       />
 
       {/* Back Button */}
-      <div className="sticky top-16 z-30 bg-white/95 backdrop-blur-sm border-b border-gray-200">
+      <div className="sticky top-16 z-30 bg-card/95 backdrop-blur-sm border-b border-border">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
           <Button 
             variant="ghost" 

--- a/src/components/NewHome.tsx
+++ b/src/components/NewHome.tsx
@@ -244,7 +244,7 @@ export function Home({ onDestinationSelect, onNavigate }: HomeProps) {
               key={index}
               onClick={() => setCurrentSlide(index)}
               className={`w-3 h-3 rounded-full transition-colors ${
-                index === currentSlide ? 'bg-white' : 'bg-white/50'
+                index === currentSlide ? 'bg-background' : 'bg-background/50'
               }`}
               aria-label={`Go to slide ${index + 1}`}
             />

--- a/src/components/NewNavigation.tsx
+++ b/src/components/NewNavigation.tsx
@@ -115,7 +115,7 @@ export function NewNavigation({ currentPage, onNavigate, user, isAdmin }: NewNav
       initial={{ y: -20, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.3 }}
-      className="fixed top-0 left-0 right-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-gray-200 dark:border-gray-700 h-16"
+      className="fixed top-0 left-0 right-0 z-50 bg-card/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-border dark:border-border h-16"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">

--- a/src/components/NewTravelListings.tsx
+++ b/src/components/NewTravelListings.tsx
@@ -166,7 +166,7 @@ export function NewTravelListings({ onDestinationSelect, onNavigate, user, isAdm
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="listings" 
         onNavigate={onNavigate} 
@@ -175,7 +175,7 @@ export function NewTravelListings({ onDestinationSelect, onNavigate, user, isAdm
       />
 
       {/* Sticky Filter Bar */}
-      <div className="sticky top-16 z-40 bg-white shadow-sm border-b border-gray-200">
+      <div className="sticky top-16 z-40 bg-card shadow-sm border-b border-border">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col md:flex-row md:items-center justify-between py-4 gap-4">
             {/* Search */}
@@ -288,7 +288,7 @@ export function NewTravelListings({ onDestinationSelect, onNavigate, user, isAdm
                         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                         
                         {/* Badges */}
-                        <Badge className="absolute top-3 left-3 bg-white/90 text-black">
+                        <Badge className="absolute top-3 left-3 bg-background/90 text-foreground">
                           {destination.category}
                         </Badge>
                         <Badge className="absolute top-3 right-3 bg-black/80 text-white">

--- a/src/components/SavedDestinations.tsx
+++ b/src/components/SavedDestinations.tsx
@@ -181,9 +181,9 @@ export function SavedDestinations({
                   />
                   
                   {/* Region Badge */}
-                  <Badge 
-                    variant="secondary" 
-                    className="absolute top-3 left-3 bg-white/90 text-gray-800"
+                  <Badge
+                    variant="secondary"
+                    className="absolute top-3 left-3 bg-background/90 text-foreground"
                   >
                     {item.region}
                   </Badge>
@@ -192,7 +192,7 @@ export function SavedDestinations({
                   <Button
                     size="sm"
                     variant="ghost"
-                    className="absolute top-3 right-3 h-8 w-8 p-0 bg-white/90 hover:bg-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                    className="absolute top-3 right-3 h-8 w-8 p-0 bg-background/90 hover:bg-background opacity-0 group-hover:opacity-100 transition-opacity duration-300"
                     onClick={(e) => {
                       e.stopPropagation();
                       handleRemoveFromSaved(item.id);
@@ -229,7 +229,7 @@ export function SavedDestinations({
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="saved" 
         onNavigate={onNavigate!} 

--- a/src/components/SavedDestinations_new.tsx
+++ b/src/components/SavedDestinations_new.tsx
@@ -184,9 +184,9 @@ export function SavedDestinations({
                   />
                   
                   {/* Region Badge */}
-                  <Badge 
-                    variant="secondary" 
-                    className="absolute top-3 left-3 bg-white/90 text-gray-800"
+                  <Badge
+                    variant="secondary"
+                    className="absolute top-3 left-3 bg-background/90 text-foreground"
                   >
                     {item.region}
                   </Badge>
@@ -195,7 +195,7 @@ export function SavedDestinations({
                   <Button
                     size="sm"
                     variant="ghost"
-                    className="absolute top-3 right-3 h-8 w-8 p-0 bg-white/90 hover:bg-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                    className="absolute top-3 right-3 h-8 w-8 p-0 bg-background/90 hover:bg-background opacity-0 group-hover:opacity-100 transition-opacity duration-300"
                     onClick={(e) => {
                       e.stopPropagation();
                       handleRemoveFromSaved(item.id);
@@ -232,7 +232,7 @@ export function SavedDestinations({
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="saved" 
         onNavigate={onNavigate!} 

--- a/src/components/TourDetails.tsx
+++ b/src/components/TourDetails.tsx
@@ -273,21 +273,21 @@ export function TourDetails({ tourId, onNavigate, user, isAdmin }: TourDetailsPr
               <span className="text-sm">Share:</span>
               <button 
                 onClick={() => handleShare('Facebook')}
-                className="p-2 bg-white/20 rounded-full hover:bg-white/30 transition-colors"
+                className="p-2 bg-background/20 rounded-full hover:bg-background/30 transition-colors"
                 aria-label="Share on Facebook"
               >
                 <Facebook className="w-5 h-5" />
               </button>
               <button 
                 onClick={() => handleShare('Twitter')}
-                className="p-2 bg-white/20 rounded-full hover:bg-white/30 transition-colors"
+                className="p-2 bg-background/20 rounded-full hover:bg-background/30 transition-colors"
                 aria-label="Share on Twitter"
               >
                 <Twitter className="w-5 h-5" />
               </button>
               <button 
                 onClick={() => handleShare('Instagram')}
-                className="p-2 bg-white/20 rounded-full hover:bg-white/30 transition-colors"
+                className="p-2 bg-background/20 rounded-full hover:bg-background/30 transition-colors"
                 aria-label="Share on Instagram"
               >
                 <Instagram className="w-5 h-5" />

--- a/src/components/ToursPage.tsx
+++ b/src/components/ToursPage.tsx
@@ -234,7 +234,7 @@ export function ToursPage({ onNavigate, onTourSelect, user, isAdmin }: ToursPage
   );
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="tours" 
         onNavigate={onNavigate} 
@@ -252,7 +252,7 @@ export function ToursPage({ onNavigate, onTourSelect, user, isAdmin }: ToursPage
         </div>
 
         {/* Filter Bar */}
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-8">
+        <div className="bg-card rounded-lg shadow-sm border border-border p-6 mb-8">
           <div className="flex flex-col lg:flex-row gap-4 items-start lg:items-center justify-between">
             <div className="flex flex-col sm:flex-row gap-4 flex-1">
               {/* Region Filter */}
@@ -398,8 +398,8 @@ export function ToursPage({ onNavigate, onTourSelect, user, isAdmin }: ToursPage
 
                     {/* View Tour Button (appears on hover) */}
                     <div className="absolute bottom-4 left-4 right-4 opacity-0 group-hover:opacity-100 transition-all duration-500 transform translate-y-4 group-hover:translate-y-0">
-                      <Button 
-                        className="w-full bg-white text-gray-900 hover:bg-gray-100"
+                      <Button
+                        className="w-full bg-background text-foreground hover:bg-muted"
                         aria-label={`View details for ${tour.title}`}
                         onClick={(e) => {
                           e.stopPropagation();

--- a/src/components/TravelListings.tsx
+++ b/src/components/TravelListings.tsx
@@ -206,7 +206,7 @@ export function TravelListings({ onDestinationSelect }: TravelListingsProps) {
                     alt={destination.name}
                     className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-700"
                   />
-                  <Badge className="absolute top-4 left-4 bg-white/90 text-black">
+                  <Badge className="absolute top-4 left-4 bg-background/90 text-foreground">
                     {destination.category}
                   </Badge>
                   <Badge className="absolute top-4 right-4 bg-black/80 text-white">

--- a/src/components/UserAccount.tsx
+++ b/src/components/UserAccount.tsx
@@ -185,7 +185,7 @@ export function UserAccount({ user, onNavigate, isAdmin }: UserAccountProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="account" 
         onNavigate={onNavigate} 
@@ -206,21 +206,21 @@ export function UserAccount({ user, onNavigate, isAdmin }: UserAccountProps) {
             <TabsTrigger 
               value="profile"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-border data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               Profile
             </TabsTrigger>
             <TabsTrigger 
               value="saved-trips"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-border data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               Saved Trips
             </TabsTrigger>
             <TabsTrigger 
               value="comments"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-border data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               My Comments
             </TabsTrigger>

--- a/src/components/UserAccount_new.tsx
+++ b/src/components/UserAccount_new.tsx
@@ -219,7 +219,7 @@ export function UserAccount({ user, onNavigate, isAdmin }: UserAccountProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="account" 
         onNavigate={onNavigate} 
@@ -240,21 +240,21 @@ export function UserAccount({ user, onNavigate, isAdmin }: UserAccountProps) {
             <TabsTrigger 
               value="profile"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-border data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               Profile
             </TabsTrigger>
             <TabsTrigger 
               value="saved-trips"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-border data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               Saved Trips
             </TabsTrigger>
             <TabsTrigger 
               value="comments"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-border data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               My Comments
             </TabsTrigger>


### PR DESCRIPTION
## Summary
- ensure card backgrounds use theme variables
- update dark mode friendly styles across pages
- adjust navigation and sticky sections for theme

## Testing
- `npm run lint` *(fails: cannot find ESLint packages / lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68888a202bc4832190802023f0527a14