### PR TITLE
Fix dark mode card backgrounds

### DIFF
--- a/src/components/AboutUs.tsx
+++ b/src/components/AboutUs.tsx
@@ -108,7 +108,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
   }, []);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="about" 
         onNavigate={onNavigate} 
@@ -131,7 +131,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
       </div>
 
       {/* Mission Section */}
-      <section ref={missionRef} className="py-16 bg-white opacity-0 transform translate-y-8">
+      <section ref={missionRef} className="py-16 bg-card opacity-0 transform translate-y-8">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div className="flex justify-center mb-6">
             <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center">
@@ -148,7 +148,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
       </section>
 
       {/* Story Section */}
-      <section ref={storyRef} className="py-16 bg-gray-50 opacity-0 transform translate-y-8">
+      <section ref={storyRef} className="py-16 bg-muted opacity-0 transform translate-y-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div>
@@ -186,7 +186,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
       </section>
 
       {/* Team Section */}
-      <section ref={teamRef} className="py-16 bg-white opacity-0 transform translate-y-8">
+      <section ref={teamRef} className="py-16 bg-card opacity-0 transform translate-y-8">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Meet Our Team</h2>
@@ -217,7 +217,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
       </section>
 
       {/* Values Section */}
-      <section ref={valuesRef} className="py-16 bg-gray-50 opacity-0 transform translate-y-8">
+      <section ref={valuesRef} className="py-16 bg-muted opacity-0 transform translate-y-8">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Our Values</h2>
@@ -266,7 +266,7 @@ export function AboutUs({ onNavigate, user, isAdmin }: AboutUsProps) {
             size="lg" 
             variant="secondary"
             onClick={() => onNavigate(user ? 'account' : 'auth')}
-            className="bg-white text-primary hover:bg-gray-100 text-lg px-8 py-3"
+              className="bg-card text-primary hover:bg-muted text-lg px-8 py-3"
           >
             {user ? 'Visit Your Account' : 'Join Our Community'}
           </Button>

--- a/src/components/AdminAddGuide.tsx
+++ b/src/components/AdminAddGuide.tsx
@@ -119,7 +119,7 @@ export function AdminAddGuide({ onNavigate, user, isAdmin }: AdminAddGuideProps)
   const isFormValid = formData.title && formData.content && formData.region && formData.category;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="admin-add-guide" 
         onNavigate={onNavigate} 
@@ -167,8 +167,8 @@ export function AdminAddGuide({ onNavigate, user, isAdmin }: AdminAddGuideProps)
           <p className="text-gray-600 mt-2">Create engaging travel content for your users</p>
         </div>
 
-        {/* Form Card */}
-        <Card className="bg-white shadow-sm border-gray-200">
+          {/* Form Card */}
+          <Card className="bg-card shadow-sm border-gray-200">
           <CardHeader className="border-b border-gray-200">
             <CardTitle className="text-xl font-bold text-gray-900">Guide Details</CardTitle>
           </CardHeader>

--- a/src/components/AdminCommentModeration.tsx
+++ b/src/components/AdminCommentModeration.tsx
@@ -160,7 +160,7 @@ export function AdminCommentModeration({ onNavigate, user, isAdmin }: AdminComme
   const flaggedCount = allComments.filter(c => c.status === 'Flagged').length;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="admin-comments" 
         onNavigate={onNavigate} 
@@ -183,7 +183,7 @@ export function AdminCommentModeration({ onNavigate, user, isAdmin }: AdminComme
         </div>
 
         {/* Main Card */}
-        <Card className="bg-white shadow-sm border-gray-200">
+        <Card className="bg-card shadow-sm border-gray-200">
           <CardHeader className="border-b border-gray-200">
             <CardTitle className="text-xl font-bold text-gray-900">Comments & Reviews</CardTitle>
           </CardHeader>
@@ -234,9 +234,9 @@ export function AdminCommentModeration({ onNavigate, user, isAdmin }: AdminComme
 
             {/* Comments Table */}
             {paginatedComments.length > 0 ? (
-              <div className="border border-gray-200 rounded-lg overflow-hidden">
+                <div className="border border-gray-200 rounded-lg overflow-hidden">
                 <Table>
-                  <TableHeader className="bg-gray-50">
+                  <TableHeader className="bg-muted">
                     <TableRow>
                       <TableHead className="w-12">
                         <Checkbox

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -75,8 +75,8 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
     }
   };
 
-  return (
-    <div className="min-h-screen bg-gray-50">
+    return (
+      <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <div className="mb-8">
@@ -86,8 +86,8 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
 
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          {stats.map((stat, index) => (
-            <Card key={index} className="bg-white shadow-sm border-gray-200">
+            {stats.map((stat, index) => (
+              <Card key={index} className="bg-card shadow-sm border-gray-200">
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div>
@@ -104,7 +104,7 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
         </div>
 
         {/* Content Management */}
-        <Card className="bg-white shadow-sm border-gray-200">
+        <Card className="bg-card shadow-sm border-gray-200">
           <CardHeader className="border-b border-gray-200">
             <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
               <CardTitle className="text-xl font-bold text-gray-900">Travel Content</CardTitle>
@@ -159,9 +159,9 @@ export function AdminDashboard({ onNavigate }: AdminDashboardProps) {
             </div>
 
             {/* Content Table */}
-            <div className="border border-gray-200 rounded-lg overflow-hidden">
-              <Table>
-                <TableHeader className="bg-gray-50">
+              <div className="border border-gray-200 rounded-lg overflow-hidden">
+                <Table>
+                  <TableHeader className="bg-muted">
                   <TableRow>
                     <TableHead className="font-medium text-gray-900">Title</TableHead>
                     <TableHead className="font-medium text-gray-900">Type</TableHead>

--- a/src/components/AdminUsers.tsx
+++ b/src/components/AdminUsers.tsx
@@ -171,7 +171,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
   const adminUsers = users.filter(u => u.role === 'Admin').length;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="admin-users" 
         onNavigate={onNavigate} 
@@ -249,7 +249,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
 
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <Card className="bg-white shadow-sm border-gray-200">
+            <Card className="bg-card shadow-sm border-gray-200">
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
@@ -262,7 +262,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
               </div>
             </CardContent>
           </Card>
-          <Card className="bg-white shadow-sm border-gray-200">
+            <Card className="bg-card shadow-sm border-gray-200">
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
@@ -275,7 +275,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
               </div>
             </CardContent>
           </Card>
-          <Card className="bg-white shadow-sm border-gray-200">
+            <Card className="bg-card shadow-sm border-gray-200">
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
@@ -291,7 +291,7 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
         </div>
 
         {/* Users Table */}
-        <Card className="bg-white shadow-sm border-gray-200">
+          <Card className="bg-card shadow-sm border-gray-200">
           <CardHeader className="border-b border-gray-200">
             <CardTitle className="text-xl font-bold text-gray-900">Users</CardTitle>
           </CardHeader>
@@ -311,9 +311,9 @@ export function AdminUsers({ onNavigate, user, isAdmin }: AdminUsersProps) {
 
             {/* Users Table */}
             {filteredUsers.length > 0 ? (
-              <div className="border border-gray-200 rounded-lg overflow-hidden">
-                <Table>
-                  <TableHeader className="bg-gray-50">
+                <div className="border border-gray-200 rounded-lg overflow-hidden">
+                  <Table>
+                    <TableHeader className="bg-muted">
                     <TableRow>
                       <TableHead className="font-medium text-gray-900">User</TableHead>
                       <TableHead className="font-medium text-gray-900">Email</TableHead>

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -170,7 +170,7 @@ export function Auth({ onAuthSuccess, onNavigate, user, isAdmin, isAdminAuth = f
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       {onNavigate && (
         <NewNavigation 
           currentPage={isAdminAuth ? "admin-auth" : "auth"} 
@@ -190,7 +190,7 @@ export function Auth({ onAuthSuccess, onNavigate, user, isAdmin, isAdminAuth = f
         />
 
         {/* Auth Card */}
-        <Card className="relative z-10 w-full max-w-md bg-white/95 backdrop-blur-sm shadow-2xl border-0">
+          <Card className="relative z-10 w-full max-w-md bg-card/95 backdrop-blur-sm shadow-2xl border-0">
         <CardHeader className="text-center pb-6 pt-8 px-8">
           <div className="w-16 h-16 bg-orange-500 rounded-xl flex items-center justify-center mx-auto mb-6 shadow-lg">
             <span className="text-white font-bold text-xl">TQ</span>
@@ -375,7 +375,7 @@ export function Auth({ onAuthSuccess, onNavigate, user, isAdmin, isAdminAuth = f
                   <span className="w-full border-t border-gray-200" />
                 </div>
                 <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-white px-3 text-gray-500 font-medium">Or continue with</span>
+                    <span className="bg-card px-3 text-gray-500 font-medium">Or continue with</span>
                 </div>
               </div>
 

--- a/src/components/BlogDetails.tsx
+++ b/src/components/BlogDetails.tsx
@@ -226,8 +226,8 @@ export function BlogDetails({ blogId, onNavigate, user, isAdmin }: BlogDetailsPr
   );
 
   if (!blog) {
-    return (
-      <div className="min-h-screen bg-white">
+      return (
+        <div className="min-h-screen bg-background">
         <NewNavigation currentPage="blogs" onNavigate={onNavigate} user={user} isAdmin={isAdmin} />
         <div className="flex items-center justify-center min-h-[50vh]">
           <div className="text-center">
@@ -239,8 +239,8 @@ export function BlogDetails({ blogId, onNavigate, user, isAdmin }: BlogDetailsPr
     );
   }
 
-  return (
-    <div className="min-h-screen bg-white">
+    return (
+      <div className="min-h-screen bg-background">
       <NewNavigation currentPage="blogs" onNavigate={onNavigate} user={user} isAdmin={isAdmin} />
 
       {/* Hero Section */}
@@ -298,7 +298,7 @@ export function BlogDetails({ blogId, onNavigate, user, isAdmin }: BlogDetailsPr
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.4, duration: 0.6 }}
-        className="bg-gray-50 py-4"
+        className="bg-muted py-4"
       >
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-wrap gap-2">

--- a/src/components/BlogsPage.tsx
+++ b/src/components/BlogsPage.tsx
@@ -219,7 +219,7 @@ export function BlogsPage({ onNavigate, onBlogSelect, user, isAdmin }: BlogsPage
   );
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="blogs" 
         onNavigate={onNavigate} 
@@ -237,7 +237,7 @@ export function BlogsPage({ onNavigate, onBlogSelect, user, isAdmin }: BlogsPage
         </div>
 
         {/* Sticky Filter Bar */}
-        <div className="sticky top-16 z-20 bg-white/95 backdrop-blur-sm border-b border-gray-200 py-4 mb-8">
+        <div className="sticky top-16 z-20 bg-card/95 backdrop-blur-sm border-b border-gray-200 py-4 mb-8">
           <div className="flex flex-col sm:flex-row gap-4">
             {/* Search */}
             <div className="relative flex-1">

--- a/src/components/ContactPage.tsx
+++ b/src/components/ContactPage.tsx
@@ -156,7 +156,7 @@ export function ContactPage({ onNavigate, user, isAdmin }: ContactPageProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="contact" 
         onNavigate={onNavigate} 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -67,18 +67,18 @@ export function Home({ onDestinationSelect, onNavigate }: HomeProps) {
             Explore breathtaking destinations with curated travel guides from local experts
           </p>
           <div className="flex flex-col sm:flex-row gap-6 justify-center">
-            <Button 
-              size="lg" 
-              onClick={() => onNavigate('listings')}
-              className="bg-white text-black hover:bg-white/90 px-8 py-4 text-lg font-semibold"
-            >
+              <Button
+                size="lg"
+                onClick={() => onNavigate('listings')}
+                className="bg-card text-card-foreground hover:bg-muted px-8 py-4 text-lg font-semibold"
+              >
               Explore Destinations
               <ArrowRight className="ml-3 w-6 h-6" />
             </Button>
             <Button 
               size="lg" 
-              variant="outline"
-              className="border-2 border-white text-white hover:bg-white hover:text-black px-8 py-4 text-lg font-semibold"
+                variant="outline"
+                className="border-2 border-white text-white hover:bg-card hover:text-card-foreground px-8 py-4 text-lg font-semibold"
             >
               Watch Travel Stories
             </Button>
@@ -109,7 +109,7 @@ export function Home({ onDestinationSelect, onNavigate }: HomeProps) {
                     alt={destination.name}
                     className="w-full h-72 object-cover group-hover:scale-105 transition-transform duration-300"
                   />
-                  <Badge className="absolute top-6 left-6 bg-white/95 text-black px-4 py-2 text-sm font-medium">
+                    <Badge className="absolute top-6 left-6 bg-card/95 text-card-foreground px-4 py-2 text-sm font-medium">
                     {destination.category}
                   </Badge>
                 </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -149,8 +149,8 @@ export function Navigation({ currentPage, onNavigate, user, isAdmin }: Navigatio
     );
   };
 
-  return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-white border-b border-gray-200 h-16 shadow-sm">
+    return (
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-card/90 backdrop-blur-md border-b border-gray-200 dark:border-gray-700 h-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}

--- a/src/components/NewDestinationDetail.tsx
+++ b/src/components/NewDestinationDetail.tsx
@@ -234,7 +234,7 @@ export function NewDestinationDetail({ destinationId, onBack, onNavigate, user, 
 
   if (isLoading || !destination) {
     return (
-      <div className="min-h-screen bg-gray-50">
+        <div className="min-h-screen bg-background">
         <NewNavigation 
           currentPage="destination" 
           onNavigate={onNavigate} 
@@ -262,7 +262,7 @@ export function NewDestinationDetail({ destinationId, onBack, onNavigate, user, 
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="destination" 
         onNavigate={onNavigate} 
@@ -271,7 +271,7 @@ export function NewDestinationDetail({ destinationId, onBack, onNavigate, user, 
       />
 
       {/* Back Button */}
-      <div className="sticky top-16 z-30 bg-white/95 backdrop-blur-sm border-b border-gray-200">
+        <div className="sticky top-16 z-30 bg-card/95 backdrop-blur-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
           <Button 
             variant="ghost" 

--- a/src/components/NewHome.tsx
+++ b/src/components/NewHome.tsx
@@ -243,9 +243,9 @@ export function Home({ onDestinationSelect, onNavigate }: HomeProps) {
             <button
               key={index}
               onClick={() => setCurrentSlide(index)}
-              className={`w-3 h-3 rounded-full transition-colors ${
-                index === currentSlide ? 'bg-white' : 'bg-white/50'
-              }`}
+                className={`w-3 h-3 rounded-full transition-colors ${
+                  index === currentSlide ? 'bg-card' : 'bg-card/50'
+                }`}
               aria-label={`Go to slide ${index + 1}`}
             />
           ))}
@@ -253,7 +253,7 @@ export function Home({ onDestinationSelect, onNavigate }: HomeProps) {
       </section>
 
       {/* About Us Section */}
-      <section className="py-20 bg-white">
+        <section className="py-20 bg-background">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid md:grid-cols-2 gap-12 items-center">
             <div className="space-y-6">
@@ -315,7 +315,7 @@ export function Home({ onDestinationSelect, onNavigate }: HomeProps) {
       </section>
 
       {/* Featured Destinations Section */}
-      <section className="py-20 bg-white">
+        <section className="py-20 bg-background">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-4xl font-bold text-center text-gray-900 mb-16">Featured Destinations</h2>
           
@@ -403,7 +403,7 @@ export function Home({ onDestinationSelect, onNavigate }: HomeProps) {
       </section>
 
       {/* Contact Us Section */}
-      <section className="py-20 bg-white">
+        <section className="py-20 bg-background">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-4xl font-bold text-center text-gray-900 mb-16">Get In Touch</h2>
           <div className="max-w-2xl mx-auto">
@@ -460,7 +460,7 @@ export function Home({ onDestinationSelect, onNavigate }: HomeProps) {
               placeholder="Enter your email"
               value={newsletterEmail}
               onChange={(e) => setNewsletterEmail(e.target.value)}
-              className="flex-1 bg-white text-gray-900"
+              className="flex-1 bg-card text-card-foreground"
               required
             />
             <Button type="submit" variant="secondary">

--- a/src/components/NewTravelListings.tsx
+++ b/src/components/NewTravelListings.tsx
@@ -165,8 +165,8 @@ export function NewTravelListings({ onDestinationSelect, onNavigate, user, isAdm
     return pages;
   };
 
-  return (
-    <div className="min-h-screen bg-gray-50">
+    return (
+      <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="listings" 
         onNavigate={onNavigate} 
@@ -175,7 +175,7 @@ export function NewTravelListings({ onDestinationSelect, onNavigate, user, isAdm
       />
 
       {/* Sticky Filter Bar */}
-      <div className="sticky top-16 z-40 bg-white shadow-sm border-b border-gray-200">
+      <div className="sticky top-16 z-40 bg-card shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col md:flex-row md:items-center justify-between py-4 gap-4">
             {/* Search */}
@@ -288,7 +288,7 @@ export function NewTravelListings({ onDestinationSelect, onNavigate, user, isAdm
                         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                         
                         {/* Badges */}
-                        <Badge className="absolute top-3 left-3 bg-white/90 text-black">
+                        <Badge className="absolute top-3 left-3 bg-card/90 text-card-foreground">
                           {destination.category}
                         </Badge>
                         <Badge className="absolute top-3 right-3 bg-black/80 text-white">

--- a/src/components/SavedDestinations.tsx
+++ b/src/components/SavedDestinations.tsx
@@ -181,9 +181,9 @@ export function SavedDestinations({
                   />
                   
                   {/* Region Badge */}
-                  <Badge 
-                    variant="secondary" 
-                    className="absolute top-3 left-3 bg-white/90 text-gray-800"
+                    <Badge
+                      variant="secondary"
+                      className="absolute top-3 left-3 bg-card/90 text-card-foreground"
                   >
                     {item.region}
                   </Badge>
@@ -192,7 +192,7 @@ export function SavedDestinations({
                   <Button
                     size="sm"
                     variant="ghost"
-                    className="absolute top-3 right-3 h-8 w-8 p-0 bg-white/90 hover:bg-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                      className="absolute top-3 right-3 h-8 w-8 p-0 bg-card/90 hover:bg-card opacity-0 group-hover:opacity-100 transition-opacity duration-300"
                     onClick={(e) => {
                       e.stopPropagation();
                       handleRemoveFromSaved(item.id);
@@ -228,8 +228,8 @@ export function SavedDestinations({
     return content;
   }
 
-  return (
-    <div className="min-h-screen bg-gray-50">
+    return (
+      <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="saved" 
         onNavigate={onNavigate!} 

--- a/src/components/SavedDestinations_new.tsx
+++ b/src/components/SavedDestinations_new.tsx
@@ -184,9 +184,9 @@ export function SavedDestinations({
                   />
                   
                   {/* Region Badge */}
-                  <Badge 
-                    variant="secondary" 
-                    className="absolute top-3 left-3 bg-white/90 text-gray-800"
+                    <Badge
+                      variant="secondary"
+                      className="absolute top-3 left-3 bg-card/90 text-card-foreground"
                   >
                     {item.region}
                   </Badge>
@@ -195,7 +195,7 @@ export function SavedDestinations({
                   <Button
                     size="sm"
                     variant="ghost"
-                    className="absolute top-3 right-3 h-8 w-8 p-0 bg-white/90 hover:bg-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                      className="absolute top-3 right-3 h-8 w-8 p-0 bg-card/90 hover:bg-card opacity-0 group-hover:opacity-100 transition-opacity duration-300"
                     onClick={(e) => {
                       e.stopPropagation();
                       handleRemoveFromSaved(item.id);
@@ -231,8 +231,8 @@ export function SavedDestinations({
     return content;
   }
 
-  return (
-    <div className="min-h-screen bg-gray-50">
+    return (
+      <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="saved" 
         onNavigate={onNavigate!} 

--- a/src/components/SupabaseSetup.tsx
+++ b/src/components/SupabaseSetup.tsx
@@ -11,7 +11,7 @@ export function SupabaseSetup() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <Card className="w-full max-w-2xl">
         <CardHeader className="text-center">
           <div className="w-16 h-16 bg-orange-500 rounded-lg flex items-center justify-center mx-auto mb-4">

--- a/src/components/TourDetails.tsx
+++ b/src/components/TourDetails.tsx
@@ -214,7 +214,7 @@ export function TourDetails({ tourId, onNavigate, user, isAdmin }: TourDetailsPr
 
   if (!tour) {
     return (
-      <div className="min-h-screen bg-gray-50">
+        <div className="min-h-screen bg-background">
         <NewNavigation currentPage="tours" onNavigate={onNavigate} user={user} isAdmin={isAdmin} />
         <div className="flex items-center justify-center min-h-[50vh]">
           <div className="text-center">
@@ -227,7 +227,7 @@ export function TourDetails({ tourId, onNavigate, user, isAdmin }: TourDetailsPr
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-background">
       <NewNavigation currentPage="tours" onNavigate={onNavigate} user={user} isAdmin={isAdmin} />
 
       {/* Hero Section */}
@@ -273,21 +273,21 @@ export function TourDetails({ tourId, onNavigate, user, isAdmin }: TourDetailsPr
               <span className="text-sm">Share:</span>
               <button 
                 onClick={() => handleShare('Facebook')}
-                className="p-2 bg-white/20 rounded-full hover:bg-white/30 transition-colors"
+                  className="p-2 bg-card/20 rounded-full hover:bg-card/30 transition-colors"
                 aria-label="Share on Facebook"
               >
                 <Facebook className="w-5 h-5" />
               </button>
               <button 
                 onClick={() => handleShare('Twitter')}
-                className="p-2 bg-white/20 rounded-full hover:bg-white/30 transition-colors"
+                className="p-2 bg-card/20 rounded-full hover:bg-card/30 transition-colors"
                 aria-label="Share on Twitter"
               >
                 <Twitter className="w-5 h-5" />
               </button>
               <button 
                 onClick={() => handleShare('Instagram')}
-                className="p-2 bg-white/20 rounded-full hover:bg-white/30 transition-colors"
+                  className="p-2 bg-card/20 rounded-full hover:bg-card/30 transition-colors"
                 aria-label="Share on Instagram"
               >
                 <Instagram className="w-5 h-5" />

--- a/src/components/ToursPage.tsx
+++ b/src/components/ToursPage.tsx
@@ -234,7 +234,7 @@ export function ToursPage({ onNavigate, onTourSelect, user, isAdmin }: ToursPage
   );
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="tours" 
         onNavigate={onNavigate} 
@@ -252,7 +252,7 @@ export function ToursPage({ onNavigate, onTourSelect, user, isAdmin }: ToursPage
         </div>
 
         {/* Filter Bar */}
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-8">
+        <div className="bg-card rounded-lg shadow-sm border border-gray-200 p-6 mb-8">
           <div className="flex flex-col lg:flex-row gap-4 items-start lg:items-center justify-between">
             <div className="flex flex-col sm:flex-row gap-4 flex-1">
               {/* Region Filter */}
@@ -310,7 +310,7 @@ export function ToursPage({ onNavigate, onTourSelect, user, isAdmin }: ToursPage
                   <DialogHeader>
                     <DialogTitle>Tour Locations</DialogTitle>
                   </DialogHeader>
-                  <div className="aspect-video bg-gray-100 flex items-center justify-center rounded-lg">
+                  <div className="aspect-video bg-muted flex items-center justify-center rounded-lg">
                     <div className="text-center">
                       <Map className="w-16 h-16 text-gray-400 mx-auto mb-4" />
                       <p className="text-gray-600">Interactive Map</p>
@@ -345,7 +345,7 @@ export function ToursPage({ onNavigate, onTourSelect, user, isAdmin }: ToursPage
           // Empty State
           <div className="text-center py-16">
             <div className="max-w-md mx-auto">
-              <div className="w-24 h-24 mx-auto mb-6 bg-gray-100 rounded-full flex items-center justify-center">
+              <div className="w-24 h-24 mx-auto mb-6 bg-muted rounded-full flex items-center justify-center">
                 <Compass className="w-12 h-12 text-gray-400" />
               </div>
               <h3 className="text-xl font-semibold text-gray-900 mb-2">No tours available</h3>
@@ -399,7 +399,7 @@ export function ToursPage({ onNavigate, onTourSelect, user, isAdmin }: ToursPage
                     {/* View Tour Button (appears on hover) */}
                     <div className="absolute bottom-4 left-4 right-4 opacity-0 group-hover:opacity-100 transition-all duration-500 transform translate-y-4 group-hover:translate-y-0">
                       <Button 
-                        className="w-full bg-white text-gray-900 hover:bg-gray-100"
+                        className="w-full bg-card text-card-foreground hover:bg-muted"
                         aria-label={`View details for ${tour.title}`}
                         onClick={(e) => {
                           e.stopPropagation();

--- a/src/components/TravelListings.tsx
+++ b/src/components/TravelListings.tsx
@@ -206,7 +206,7 @@ export function TravelListings({ onDestinationSelect }: TravelListingsProps) {
                     alt={destination.name}
                     className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-700"
                   />
-                  <Badge className="absolute top-4 left-4 bg-white/90 text-black">
+                    <Badge className="absolute top-4 left-4 bg-card/90 text-card-foreground">
                     {destination.category}
                   </Badge>
                   <Badge className="absolute top-4 right-4 bg-black/80 text-white">

--- a/src/components/UserAccount.tsx
+++ b/src/components/UserAccount.tsx
@@ -185,7 +185,7 @@ export function UserAccount({ user, onNavigate, isAdmin }: UserAccountProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="account" 
         onNavigate={onNavigate} 
@@ -206,21 +206,21 @@ export function UserAccount({ user, onNavigate, isAdmin }: UserAccountProps) {
             <TabsTrigger 
               value="profile"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               Profile
             </TabsTrigger>
             <TabsTrigger 
               value="saved-trips"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               Saved Trips
             </TabsTrigger>
             <TabsTrigger 
               value="comments"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               My Comments
             </TabsTrigger>

--- a/src/components/UserAccount_new.tsx
+++ b/src/components/UserAccount_new.tsx
@@ -219,7 +219,7 @@ export function UserAccount({ user, onNavigate, isAdmin }: UserAccountProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <NewNavigation 
         currentPage="account" 
         onNavigate={onNavigate} 
@@ -240,21 +240,21 @@ export function UserAccount({ user, onNavigate, isAdmin }: UserAccountProps) {
             <TabsTrigger 
               value="profile"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               Profile
             </TabsTrigger>
             <TabsTrigger 
               value="saved-trips"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               Saved Trips
             </TabsTrigger>
             <TabsTrigger 
               value="comments"
               role="tab"
-              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              className="rounded-full data-[state=active]:bg-primary data-[state=active]:text-white border border-gray-200 data-[state=inactive]:bg-card data-[state=inactive]:text-gray-700 hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             >
               My Comments
             </TabsTrigger>


### PR DESCRIPTION
## Summary
- ensure cards and page sections use theme colors
- keep navigation semi-transparent

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68888a202bc4832190802023f0527a14